### PR TITLE
fix(Select) preserve native select tabIndex value 

### DIFF
--- a/src/select.ts
+++ b/src/select.ts
@@ -44,6 +44,7 @@ export class FormSelect extends Component<FormSelectOptions> {
   wrapper: HTMLDivElement;
   selectOptions: (HTMLOptionElement | HTMLOptGroupElement)[];
   private _values: ValueStruct[];
+  nativeTabIndex: number;
 
   constructor(el: HTMLSelectElement, options: FormSelectOptions) {
     super(el, options, FormSelect);
@@ -56,6 +57,7 @@ export class FormSelect extends Component<FormSelectOptions> {
     };
 
     this.isMultiple = this.el.multiple;
+    this.nativeTabIndex = (this.el.tabIndex ?? -1);
     this.el.tabIndex = -1;
     this._values = [];
     this._setupDropdown();
@@ -258,6 +260,7 @@ export class FormSelect extends Component<FormSelectOptions> {
     this.input.ariaReadOnly = 'true';
     this.input.ariaRequired = this.el.hasAttribute('required').toString(); //setAttribute("aria-required", this.el.hasAttribute("required"));
     if (this.el.disabled) this.input.disabled = true; // 'true');
+    this.input.setAttribute('tabindex', this.nativeTabIndex.toString());
 
     const attrs = this.el.attributes;
     for (let i = 0; i < attrs.length; ++i) {


### PR DESCRIPTION
## Proposed changes
This change resolves issue #510 by assigning the tabIndex value from the native select element to the input element created during initialization.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
